### PR TITLE
Fix permission check condition ch7/LBYL.py

### DIFF
--- a/code/ch7/LBYL.py
+++ b/code/ch7/LBYL.py
@@ -6,7 +6,7 @@ if os.path.exists(iname):
        line = fh.readline()
    if "\t" in line:
        value = line.split('\t')[0]
-       if os.access(oname, os.W_OK) == 0:
+       if os.access(oname, os.W_OK):
            with open(oname, 'w') as fw:
                if value.isdigit():
                    fw.write(str(int(value)*.2))


### PR DESCRIPTION
`os.access(file, os.W_OK)` return boolean value.

[os — Miscellaneous operating system interfaces — Python 3\.8\.3 documentation](https://docs.python.org/3/library/os.html#os.access)

Line 9: need to fix
Current code compare boolean `False` and number 0 , this is opposite from desired behavior.

Check by my environment
```
$ touch readonly.txt
$ chmod 444 readonly.txt
```

check python

```
>>> os.access("readonly.txt", os.W_OK)
False
>>> os.access("readonly.txt", os.W_OK)==0
True
```